### PR TITLE
update the pyarrow package to make Step 2  in 01_introduction_to_diffusers.ipynb reproducible

### DIFF
--- a/unit1/01_introduction_to_diffusers.ipynb
+++ b/unit1/01_introduction_to_diffusers.ipynb
@@ -83,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -qq -U diffusers datasets transformers accelerate ftfy"
+    "%pip install -qq -U diffusers datasets transformers accelerate ftfy pyarrow"
    ]
   },
   {


### PR DESCRIPTION
In order to make "Step 2: Download a training dataset" work on Kaggle (following the [Notebook](https://www.kaggle.com/code/kashnitsky/notebook387b43986a/edit) shared in the Readme file), I had to install a version of `pyarrow > 6.0.0`. 