### PR TITLE
Fix typos in unit1

### DIFF
--- a/unit1/01_introduction_to_diffusers.ipynb
+++ b/unit1/01_introduction_to_diffusers.ipynb
@@ -273,7 +273,7 @@
     "id": "6ttDW4giJCvY"
    },
    "source": [
-    "Here's an example using [a model](https://huggingface.co/sd-dreambooth-library/mr-potato-head) trained on 5 photos of a popular childrens toy called \"Mr Potato Head\".\n",
+    "Here's an example using [a model](https://huggingface.co/sd-dreambooth-library/mr-potato-head) trained on 5 photos of a popular children's toy called \"Mr Potato Head\".\n",
     "\n",
     "First, we load the pipeline. This will download model weights etc. from the Hub. Since this will download several gigabytes of data for a one-line demo, you are welcome to skip this cell and simply admire the example output!"
    ]
@@ -518,8 +518,7 @@
     "4.   Evaluate how well the model does at denoising these inputs\n",
     "5.   Use this information to update the model weights, and repeat\n",
     "\n",
-    "We'll explore these steps one by one in the next few sections until we have a complete training loop working, and then we'll explore how to sample from the trained model and how to package everything up into a pipeline for easy sharing. Let's begin with the data...\n",
-    "\n"
+    "We'll explore these steps one by one in the next few sections until we have a complete training loop working, and then we'll explore how to sample from the trained model and how to package everything up into a pipeline for easy sharing. Let's begin with the data..."
    ]
   },
   {
@@ -832,7 +831,7 @@
     "In a nutshell:\n",
     "- the model has the input image go through several blocks of ResNet layers, each of which halves the image size by 2\n",
     "- then through the same number of blocks that upsample it again.\n",
-    "- there are skip connections linking the features on the downample path to the corresponsding layers in the upsample path.\n",
+    "- there are skip connections linking the features on the downsample path to the corresponding layers in the upsample path.\n",
     "\n",
     "A key feature of this model is that it predicts images of the same size as the input, which is exactly what we need here.\n",
     "\n",
@@ -1252,7 +1251,7 @@
     "id": "vypV6Joh2vE7"
    },
    "source": [
-    "The `scheduler` and `unet` subfolders contain everything needed to re-create those components. For example, inside the `unet` folder you'll find the model weights (`diffusion_pytorch_model.bin`) alongside a config file which specifies the unet architecture. "
+    "The `scheduler` and `unet` subfolders contain everything needed to re-create those components. For example, inside the `unet` folder you'll find the model weights (`diffusion_pytorch_model.bin`) alongside a config file which specifies the UNet architecture. "
    ]
   },
   {
@@ -1284,7 +1283,7 @@
     "id": "L2_tiRgS7-qh"
    },
    "source": [
-    "Together, these files contain everything needed to recreate the pipeline. You can manually upload them to the hub to share the pipeline with others, or check out the code to do this via the API in the next setcion."
+    "Together, these files contain everything needed to recreate the pipeline. You can manually upload them to the hub to share the pipeline with others, or check out the code to do this via the API in the next section."
    ]
   },
   {
@@ -1373,7 +1372,7 @@
    "source": [
     "## Step 7: Push your model to the Hub\n",
     "\n",
-    "In the example above we saved our pipeline to a local folder. To push our model to the Hub, we will need to model repository to push our files to. We’ll determine the repository name from the model ID we want to give our model (feel free to replace the `model_name` with your own choice; it just needs to contain your username, which is what the function `get_full_repo_name()` does):"
+    "In the example above we saved our pipeline to a local folder. To push our model to the Hub, we will need to model repository to push our files to. We'll determine the repository name from the model ID we want to give our model (feel free to replace the `model_name` with your own choice; it just needs to contain your username, which is what the function `get_full_repo_name()` does):"
    ]
   },
   {
@@ -1475,7 +1474,7 @@
     "```python\n",
     "from diffusers import DDPMPipeline\n",
     "\n",
-    "pipeline = DDPMPipeline.from_pretrained({hub_model_id})\n",
+    "pipeline = DDPMPipeline.from_pretrained('{hub_model_id}')\n",
     "image = pipeline().images[0]\n",
     "image\n",
     "```\n",
@@ -1685,7 +1684,7 @@
     "```python\n",
     "from diffusers import DDPMPipeline\n",
     "\n",
-    "pipeline = DDPMPipeline.from_pretrained({hub_model_id})\n",
+    "pipeline = DDPMPipeline.from_pretrained('{hub_model_id}')\n",
     "image = pipeline().images[0]\n",
     "image\n",
     "```\n",
@@ -1782,7 +1781,7 @@
     "\n",
     "- Try training an unconditional diffusion model on a new dataset - bonus points if you [create one yourself](https://huggingface.co/docs/datasets/image_dataset). You can find some great image datasets for this task in the [HugGan organization](https://huggingface.co/huggan) on the Hub. Just make sure you downsample them if you don't want to wait a very long time for the model to train!\n",
     "- Try out DreamBooth to create your own customized Stable Diffusion pipeline using either [this Space](https://huggingface.co/spaces/multimodalart/dreambooth-training) or [this notebook](https://colab.research.google.com/github/huggingface/notebooks/blob/main/diffusers/sd_dreambooth_training.ipynb)\n",
-    "- Modify the training script to explore different unet hyperparameters (number of layers, channels etc), different noise schedules etc.\n",
+    "- Modify the training script to explore different UNet hyperparameters (number of layers, channels etc), different noise schedules etc.\n",
     "- Check out the [Diffusion Models from Scratch](https://github.com/huggingface/diffusion-models-class/blob/unit1/unit1/02_diffusion_models_from_scratch.ipynb) notebook for a different take on the core ideas we've covered in this unit\n",
     "\n",
     "Good luck, and stay tuned for Unit 2!"
@@ -1810,7 +1809,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {

--- a/unit1/01_introduction_to_diffusers.ipynb
+++ b/unit1/01_introduction_to_diffusers.ipynb
@@ -83,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -qq -U diffusers datasets transformers accelerate ftfy"
+    "%pip install -qq -U diffusers datasets transformers accelerate ftfy pyarrow"
    ]
   },
   {

--- a/unit1/02_diffusion_models_from_scratch.ipynb
+++ b/unit1/02_diffusion_models_from_scratch.ipynb
@@ -438,7 +438,7 @@
     "\n",
     "We'd like a model that takes in a 28px noisy images and outputs a prediction of the same shape. A popular choice here is an architecture called a UNet. [Originally invented for segmentation tasks in medical imagery](https://arxiv.org/abs/1505.04597), a UNet consists of a 'constricting path' through which data is compressed down and an 'expanding path' through which it expands back up to the original dimension (similar to an autoencoder) but also features skip connections that allow for information and gradients to flow across at different levels. \n",
     "\n",
-    "Some UNets feature complex blocks at each stage, but for this toy demo we'll build a minimal example that takes in a one-channel image and passes it through three convolutional layers on the down path (the down_layers in the diagram and code) and three on the up path, with skip connections between the down and up layers. We'll use max pooling for downsampling and nn.Upsample for upsampling rather than relying on learnable layers like more complex UNets. Here is the rough architecture showing the number of channels in the output of each layer:"
+    "Some UNets feature complex blocks at each stage, but for this toy demo we'll build a minimal example that takes in a one-channel image and passes it through three convolutional layers on the down path (the down_layers in the diagram and code) and three on the up path, with skip connections between the down and up layers. We'll use max pooling for downsampling and `nn.Upsample` for upsampling rather than relying on learnable layers like more complex UNets. Here is the rough architecture showing the number of channels in the output of each layer:"
    ]
   },
   {
@@ -890,7 +890,7 @@
     "id": "Mo1OsL6y568K"
    },
    "source": [
-    "Not great, but there are some recognizeable digits there! You can experiment with training for longer (say, 10 or 20 epochs) and tweaking model config, learning rate, optimizer and so on. Also, don't forget that fashionMNIST is a one-line replacement if you want a slightly harder dataset to try."
+    "Not great, but there are some recognizable digits there! You can experiment with training for longer (say, 10 or 20 epochs) and tweaking model config, learning rate, optimizer and so on. Also, don't forget that fashionMNIST is a one-line replacement if you want a slightly harder dataset to try."
    ]
   },
   {
@@ -906,7 +906,7 @@
     "We'll see that\n",
     "\n",
     "\n",
-    "*   The diffusers UNet2DModel is a bit more advanced than our BasicUNet\n",
+    "*   The diffusers `UNet2DModel` is a bit more advanced than our BasicUNet\n",
     "*   The corruption process in handled differently\n",
     "*   The training objective is different, involving predicting the noise rather than the denoised image\n",
     "*   The model is conditioned on the amount of noise present via timestep conditioning, where t is passed as an additional argument to the forward method.\n",
@@ -927,7 +927,7 @@
    "source": [
     "### The UNet\n",
     "\n",
-    "The diffusers UNet2DModel model has a number of improvements over our basic unet above:\n",
+    "The diffusers UNet2DModel model has a number of improvements over our basic UNet above:\n",
     "\n",
     "*   GroupNorm applies group normalization to the inputs of each block\n",
     "*   Dropout layers for smoother training\n",
@@ -1542,7 +1542,7 @@
     "id": "OdV1cYbbdrVN"
    },
    "source": [
-    "Initially, the noisy x is mostly x (sqrt_alpha_prod ~= 1) but over time the contributon of x drops and the noise component increases. Unlike our linear mix of x and noise accrding to `amount`, this one gets noisy relatively quickly. We can visualize this on some data:"
+    "Initially, the noisy x is mostly x (sqrt_alpha_prod ~= 1) but over time the contribution of x drops and the noise component increases. Unlike our linear mix of x and noise according to `amount`, this one gets noisy relatively quickly. We can visualize this on some data:"
    ]
   },
   {
@@ -1612,7 +1612,7 @@
     "id": "Urw8pxRueFHs"
    },
    "source": [
-    "Another dynamic at play: the DDPM version adds noise drawn from a gaussian distribution (mean 0, s.d. 1 from torch.randn) rather than the uniform noise between 0 and 1 (from torch.rand) we used in our original `corrupt` function. In general, it makes sense to normalize the training data as well. In the other notebook, you'll see `Normalize(0.5, 0.5)` in the list of transforms, which maps the image data form (0, 1) to (-1, 1) and is 'good enough' for our purposes. We didn't do that for this notebook, but the visualization cell above adds it in for more accurate scaling and visualization."
+    "Another dynamic at play: the DDPM version adds noise drawn from a Gaussian distribution (mean 0, s.d. 1 from torch.randn) rather than the uniform noise between 0 and 1 (from torch.rand) we used in our original `corrupt` function. In general, it makes sense to normalize the training data as well. In the other notebook, you'll see `Normalize(0.5, 0.5)` in the list of transforms, which maps the image data form (0, 1) to (-1, 1) and is 'good enough' for our purposes. We didn't do that for this notebook, but the visualization cell above adds it in for more accurate scaling and visualization."
    ]
   },
   {
@@ -1634,7 +1634,7 @@
     "\n",
     "You may think that predicting the noise (from which we can derive what the denoised image looks like) is equivalent to just predicting the denoised image directly. So why favour one over the other - is it just for mathematical convenience?\n",
     "\n",
-    "It turns out there's another subtlety here. We compute the loss across different (randomly chosen) timesteps during training. These different objectives will lead to different 'implicit weighting' of these losses, where predicting the noise puts more weight on lower noise levels. You can pick more complex objectives to change this 'implicit loss weighting'. Or perhaps you choose a noise schedule that will result in more examples at a higher noise level. Perhaps you have the model predict a 'velocity' v which we define as being a combination of both the image and the noise dependant on the noise level (see 'PROGRESSIVE DISTILLATION FOR FAST SAMPLING OF DIFFUSION MODELS'). Perhaps you have the model predict the noise but then scale the loss by some factor dependant on the amount of noise based on a bit of theory (see 'Perception Prioritized Training of Diffusion Models') or based on experiments trying to see what noise levels are most informative to the model (see 'Elucidating the Design Space of Diffusion-Based Generative Models'). TL;DR: choosing the objective has an effect on model performance, and research in ongoing into what the 'best' option is.\n",
+    "It turns out there's another subtlety here. We compute the loss across different (randomly chosen) timesteps during training. These different objectives will lead to different 'implicit weighting' of these losses, where predicting the noise puts more weight on lower noise levels. You can pick more complex objectives to change this 'implicit loss weighting'. Or perhaps you choose a noise schedule that will result in more examples at a higher noise level. Perhaps you have the model predict a 'velocity' v which we define as being a combination of both the image and the noise dependent on the noise level (see 'PROGRESSIVE DISTILLATION FOR FAST SAMPLING OF DIFFUSION MODELS'). Perhaps you have the model predict the noise but then scale the loss by some factor dependent on the amount of noise based on a bit of theory (see 'Perception Prioritized Training of Diffusion Models') or based on experiments trying to see what noise levels are most informative to the model (see 'Elucidating the Design Space of Diffusion-Based Generative Models'). TL;DR: choosing the objective has an effect on model performance, and research in ongoing into what the 'best' option is.\n",
     "\n",
     "At the moment, predicting the noise (epsilon or eps you'll see in some places) is the favoured approach but over time we will likely see other objectives supported in the library and used in different situations. \n",
     "\n"
@@ -1665,7 +1665,7 @@
     "\n",
     "We could feed in pure noise, and hope that the model predicts a good image as the denoised version in one step. However, as we saw in the experiments above, this doesn't usually work well. So, instead, we take a number of smaller steps based on the model prediction, iteratively removing a little bit of the noise at a time.\n",
     "\n",
-    "Exactly how we take these steps depends on the sampling method used. We won't go into the thoery too deeply, but some key design questions are:\n",
+    "Exactly how we take these steps depends on the sampling method used. We won't go into the theory too deeply, but some key design questions are:\n",
     "- How large of a step should you take? In other words, what 'noise schedule' should you follow?\n",
     "- Do you use only the model's current prediction to inform the update step (like DDPM, DDIM and many others)? Do you evaluate the model several times to estimate higher-order gradients for a larger, more accurate step (higher order methods and some discrete ODE solvers)? Or do you keep a history of past predictions to try and better inform the current update step (linear multi-step and ancestral samplers). \n",
     "- Do you add in additional noise (sometimes called churn) to add more stochasticity (randomness) to the sampling process, or do you keep it completely deterministic? Many samplers control this with a parameter (such as 'eta' for DDIM samplers) so that the user can choose.\n",
@@ -1685,13 +1685,6 @@
     "\n",
     "This notebook was written for this Hugging Face course by Jonathan Whitaker, and overlaps with a [version included in his own course](https://johnowhitaker.github.io/tglcourse/dm1.html), 'The Generative Landscape'. Check that out if you'd like to see this basic example extended with noise and class conditioning. Questions or bugs can be communicated through GitHub issues or via Discord. You are also welcome to reach out via Twitter [@johnowhitaker](https://twitter.com/johnowhitaker)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1719,7 +1712,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Minor typos fixed in `unit1/01_introduction_to_diffusers.ipynb` and `unit1/02_diffusion_models_from_scratch.ipynb`