### PR TITLE
Fixed diffusers_library broken icon url.

### DIFF
--- a/unit1/01_introduction_to_diffusers.ipynb
+++ b/unit1/01_introduction_to_diffusers.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Introduction to 🤗 Diffusers\n",
     "\n",
-    "![diffusers_library](https://github.com/huggingface/diffusers/raw/main/docs/source/imgs/diffusers_library.jpg)"
+    "![diffusers_library](https://github.com/huggingface/diffusers/raw/main/docs/source/en/imgs/diffusers_library.jpg)"
    ]
   },
   {


### PR DESCRIPTION
Before: https://github.com/huggingface/diffusers/raw/main/docs/source/imgs/diffusers_library.jpg
After: https://github.com/huggingface/diffusers/raw/main/docs/source/en/imgs/diffusers_library.jpg